### PR TITLE
add receipe files for building CentOS7 containers with MPI and CUDA support

### DIFF
--- a/recipes/Singularity.centos-7-cuda
+++ b/recipes/Singularity.centos-7-cuda
@@ -1,0 +1,37 @@
+Bootstrap: docker
+From: nvidia/cuda:12.2.0-devel-centos7
+
+%files
+    #mpitest.c /opt
+    /opt
+
+%environment
+    export OMPI_DIR=/opt/ompi
+    export SINGULARITY_OMPI_DIR=$OMPI_DIR
+    export SINGULARITYENV_APPEND_PATH=$OMPI_DIR/bin
+    export SINGULAIRTYENV_APPEND_LD_LIBRARY_PATH=$OMPI_DIR/lib
+    export PATH=/opt/ompi/bin:$PATH
+    export LD_LIBRARY_PATH=/opt/ompi/lib:$LD_LIBRARY_PATH
+
+%post
+    echo "Installing required packages..."
+    yum install -y bzip2 perl
+
+    echo "Installing Open MPI"
+    export OMPI_DIR=/opt/ompi
+    export OMPI_VERSION=4.0.1
+    export OMPI_URL="https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-$OMPI_VERSION.tar.bz2"
+    mkdir -p /tmp/ompi
+    mkdir -p /opt
+    # Download
+    #cd /tmp/ompi && curl -O openmpi-$OMPI_VERSION.tar.bz2 $OMPI_URL && tar -xjf openmpi-$OMPI_VERSION.tar.bz2
+    cd /tmp/ompi && curl -O $OMPI_URL && tar -xjf openmpi-$OMPI_VERSION.tar.bz2
+    # Compile and install
+    cd /tmp/ompi/openmpi-$OMPI_VERSION && ./configure --prefix=$OMPI_DIR && make install
+    # Set env variables so we can compile our application
+    export PATH=$OMPI_DIR/bin:$PATH
+    export LD_LIBRARY_PATH=$OMPI_DIR/lib:$LD_LIBRARY_PATH
+    export MANPATH=$OMPI_DIR/share/man:$MANPATH
+
+    #echo "Compiling the MPI application..."
+    #cd /opt && mpicc -o mpitest mpitest.c

--- a/recipes/Singularity.centos-7-mpi
+++ b/recipes/Singularity.centos-7-mpi
@@ -1,0 +1,38 @@
+Bootstrap: docker
+From: centos:7.7.1908
+
+
+%files
+    #mpitest.c /opt
+    /opt
+
+%environment
+    export OMPI_DIR=/opt/ompi
+    export SINGULARITY_OMPI_DIR=$OMPI_DIR
+    export SINGULARITYENV_APPEND_PATH=$OMPI_DIR/bin
+    export SINGULAIRTYENV_APPEND_LD_LIBRARY_PATH=$OMPI_DIR/lib
+    export PATH=/opt/ompi/bin:$PATH
+    export LD_LIBRARY_PATH=/opt/ompi/lib:$LD_LIBRARY_PATH
+
+%post
+    echo "Installing required packages..."
+    yum install -y bzip2 perl gcc gcc-c++ make
+
+    echo "Installing Open MPI"
+    export OMPI_DIR=/opt/ompi
+    export OMPI_VERSION=4.0.1
+    export OMPI_URL="https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-$OMPI_VERSION.tar.bz2"
+    mkdir -p /tmp/ompi
+    mkdir -p /opt
+    # Download
+    #cd /tmp/ompi && curl -O openmpi-$OMPI_VERSION.tar.bz2 $OMPI_URL && tar -xjf openmpi-$OMPI_VERSION.tar.bz2
+    cd /tmp/ompi && curl -O $OMPI_URL && tar -xjf openmpi-$OMPI_VERSION.tar.bz2
+    # Compile and install
+    cd /tmp/ompi/openmpi-$OMPI_VERSION && ./configure --prefix=$OMPI_DIR && make install
+    # Set env variables so we can compile our application
+    export PATH=$OMPI_DIR/bin:$PATH
+    export LD_LIBRARY_PATH=$OMPI_DIR/lib:$LD_LIBRARY_PATH
+    export MANPATH=$OMPI_DIR/share/man:$MANPATH
+
+    #echo "Compiling the MPI application..."
+    #cd /opt && mpicc -o mpitest mpitest.c


### PR DESCRIPTION
Note that the CUDA containers from NVIDIA are huge.

There was some discussion at the GlueX software meeting today that someone (at the lab?) might know how to slim them down...